### PR TITLE
17358 client incorporate

### DIFF
--- a/lib/synapse_pay_rest.rb
+++ b/lib/synapse_pay_rest.rb
@@ -7,6 +7,7 @@ require 'synapse_pay_rest/api/users'
 require 'synapse_pay_rest/api/nodes'
 require 'synapse_pay_rest/api/subnets'
 require 'synapse_pay_rest/api/transactions'
+require 'synapse_pay_rest/api/dummy_transactions'
 require 'synapse_pay_rest/api/subscriptions'
 require 'synapse_pay_rest/api/institutions'
 require 'synapse_pay_rest/api/client'
@@ -77,6 +78,7 @@ require 'synapse_pay_rest/models/subnet/subnet'
 
 # transaction-related classes
 require 'synapse_pay_rest/models/transaction/transaction'
+require 'synapse_pay_rest/models/transaction/dummy_transaction'
 
 # subscription-related classes
 require 'synapse_pay_rest/models/subscription/subscription'

--- a/lib/synapse_pay_rest/api/dummy_transactions.rb
+++ b/lib/synapse_pay_rest/api/dummy_transactions.rb
@@ -1,0 +1,17 @@
+module SynapsePayRest
+  class DummyTransactions < Transactions
+
+    def create(user_id:, node_id:, payload:, idempotency_key: nil)
+      path = create_transaction_path(user_id: user_id, node_id: node_id)
+      client.get("#{path}?#{payload.to_query}")
+    end
+
+    private
+
+    def create_transaction_path(user_id:, node_id:, trans_id: nil)
+      path = "/users/#{user_id}/nodes/#{node_id}/dummy-tran"
+      path += "/#{trans_id}" if trans_id
+      path
+    end
+  end
+end

--- a/lib/synapse_pay_rest/client.rb
+++ b/lib/synapse_pay_rest/client.rb
@@ -14,7 +14,7 @@ module SynapsePayRest
     # @!attribute [rw] subscriptions
     #   @return [SynapsePayRest::Subscriptions]
     attr_accessor :http_client, :users, :nodes, :subnets, :transactions, :subscriptions, :institutions,
-                  :client_endpoint, :atms, :crypto_quotes, :statements
+                  :client_endpoint, :atms, :crypto_quotes, :statements, :development_mode
 
     # Alias for #transactions (legacy name)
     alias_method :trans, :transactions
@@ -41,6 +41,7 @@ module SynapsePayRest
                                      client_secret: client_secret,
                                      fingerprint: fingerprint,
                                      ip_address: ip_address,
+                                     development_mode: development_mode,
                                      **options)
       @users            = Users.new @http_client
       @nodes            = Nodes.new @http_client
@@ -52,6 +53,8 @@ module SynapsePayRest
       @atms             = Atms.new @http_client
       @crypto_quotes    = CryptoQuotes.new @http_client
       @statements       = Statements.new @http_client
+      @dummy_transactions = DummyTransactions.new @http_client
+
     end
 
   

--- a/lib/synapse_pay_rest/models/client/issue_public_key.rb
+++ b/lib/synapse_pay_rest/models/client/issue_public_key.rb
@@ -18,7 +18,7 @@ module SynapsePayRest
           public_key:                response['public_key_obj']['public_key'],
           scope:                     response['public_key_obj']['scope']
         }
-        self.new(args)
+        self.new(**args)
       end
 
       #Issues public key for client.

--- a/lib/synapse_pay_rest/models/crypto_quote/crypto_quote.rb
+++ b/lib/synapse_pay_rest/models/crypto_quote/crypto_quote.rb
@@ -19,7 +19,7 @@ module SynapsePayRest
           usdbtc:        response['USDBTC'],
           usdeth:        response['USDETH']
         }
-        self.new(args)
+        self.new(**args)
       end
 
       def get(client:)

--- a/lib/synapse_pay_rest/models/transaction/dummy_transaction.rb
+++ b/lib/synapse_pay_rest/models/transaction/dummy_transaction.rb
@@ -1,0 +1,29 @@
+module SynapsePayRest
+    class DummyTransaction < Transaction
+      attr_reader :dummy_transactions
+  
+      class << self
+        def create(node:, to_type:, to_id:, amount:, currency:, ip:, **options)
+          raise ArgumentError, 'cannot create a transaction with an UnverifiedNode' if node.is_a?(UnverifiedNode)
+          raise ArgumentError, 'node must be a type of BaseNode object' unless node.is_a?(BaseNode)
+          raise ArgumentError, 'amount must be a Numeric (Integer or Float)' unless amount.is_a?(Numeric)
+          [to_type, to_id, currency, ip].each do |arg|
+            if options[arg] && !options[arg].is_a?(String)
+              raise ArgumentError, "#{arg} must be a String"
+            end
+          end
+  
+          payload = payload_for_create(node: node, to_type: to_type, to_id: to_id,
+            amount: amount, currency: currency, ip: ip, **options)
+          response = node.user.client.dummy_transactions.create(
+            user_id: node.user.id,
+            node_id: node.id,
+            payload: payload,
+            idempotency_key: options[:idempotency_key],
+          )
+          from_response(node, response)
+        end
+      end
+    end
+  end
+  

--- a/lib/synapse_pay_rest/models/transaction/transaction.rb
+++ b/lib/synapse_pay_rest/models/transaction/transaction.rb
@@ -166,15 +166,46 @@ module SynapsePayRest
             'ip' => ip
           }
         }
+
         # optional payload fields
         payload['extra']['asset']      = options[:asset] if options[:asset]
         payload['extra']['same_day']   = options[:same_day] if options[:same_day]
         payload['extra']['supp_id']    = options[:supp_id] if options[:supp_id]
         payload['extra']['note']       = options[:note] if options[:note]
         payload['extra']['process_on'] = options[:process_in] if options[:process_in]
+
+
+        # here is the hacks
+        # for interchange meta object
+        # reference:
+        #   https://docs.synapsefi.com/api-references/transactions/transaction-object-details#interchange-meta-fields
+        #
+        # ----------------------------------------------------------------------
+        #
+        if options[:soft_descriptor]
+          payload['extra']['interchange_meta'] = {
+            'soft_descriptor' => options[:soft_descriptor]                            # science - 1
+          }
+        end
+
+        # ----------------------------------------------------------------------
+
+        # other payload fields
         other = {}
         other['attachments'] = options[:attachments] if options[:attachments]
+
+        # # I don't know where I've to put soft_descriptor
+        # # if put in extra not works, probably we need to put under `other`
+        # #
+        # if options[:soft_descriptor]
+        #   other['soft_descriptor'] = options[:soft_descriptor]                        # science - 2
+        #
+        #   other['interchange_meta'] ||= {}
+        #   other['interchange_meta']['soft_descriptor'] = options[:soft_descriptor]    # science - 3
+        # end
+
         payload['extra']['other'] = other if other.any?
+
         fees = []
         # deprecated fee flow
         fee = {}
@@ -187,6 +218,7 @@ module SynapsePayRest
         # new fee flow
         fees = options[:fees] if options[:fees]
         payload['fees'] = fees if fees.any?
+
         payload
       end
 

--- a/synapse_pay_rest.gemspec
+++ b/synapse_pay_rest.gemspec
@@ -27,7 +27,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'minitest', '~> 5.8.2'
   s.add_development_dependency 'minitest-reporters', '~> 1.1.5'
   s.add_development_dependency 'dotenv', '~> 2.1.1'
-  s.add_development_dependency 'faker', '~> 1.6.6'
+  s.add_development_dependency 'faker', '~> 2.21.0'
   s.add_development_dependency 'simplecov', '~> 0.12.0'
   s.add_development_dependency 'm', '~> 1.5.0'
+  s.add_development_dependency 'psych', '< 4'
 end

--- a/test/factories/users_payloads.rb
+++ b/test/factories/users_payloads.rb
@@ -1,5 +1,5 @@
 def test_users_create_payload(email: Faker::Internet.email,
-                              password: Faker::Internet..password(min_length: 8, max_length: 8, mix_case: true, special_characters: true) + 'Ay&1',
+                              password: Faker::Internet.password(min_length: 8, max_length: 8, mix_case: true, special_characters: true) + 'Ay&1',
                               read_only: false,
                               phone_number: Faker::PhoneNumber.phone_number,
                               legal_name: Faker::Name.first_name + ' ' + Faker::Name.last_name,

--- a/test/factories/users_payloads.rb
+++ b/test/factories/users_payloads.rb
@@ -1,10 +1,10 @@
 def test_users_create_payload(email: Faker::Internet.email,
-                              password: Faker::Internet.password,
+                              password: Faker::Internet..password(min_length: 8, max_length: 8, mix_case: true, special_characters: true) + 'Ay&1',
                               read_only: false,
                               phone_number: Faker::PhoneNumber.phone_number,
                               legal_name: Faker::Name.first_name + ' ' + Faker::Name.last_name,
-                              note: Faker::Hipster.sentence(3),
-                              supp_id: Faker::Number.number(10).to_s,
+                              note: Faker::Hipster.sentence(word_count: 3),
+                              supp_id: Faker::Number.number(digits: 10).to_s,
                               is_business: false)
   {
     'logins' => [

--- a/test/synapse_pay_rest/client_test.rb
+++ b/test/synapse_pay_rest/client_test.rb
@@ -12,7 +12,7 @@ class ClientTest < Minitest::Test
   end
 
   def test_configured_through_options
-    client = SynapsePayRest::Client.new(@options)
+    client = SynapsePayRest::Client.new(**@options)
     # these keys don't exist in config
     @options.delete(:development_mode)
     @options[:oauth_key] = ''
@@ -23,12 +23,12 @@ class ClientTest < Minitest::Test
 
   def test_endpoint_changes_when_development_mode_false
     @options[:development_mode] = false
-    client = SynapsePayRest::Client.new(@options)
+    client = SynapsePayRest::Client.new(**@options)
     assert_equal client.client.base_url, 'https://api.synapsefi.com/v3.1'
   end
 
   def test_instance_reader_methods
-    client = SynapsePayRest::Client.new(@options)
+    client = SynapsePayRest::Client.new(**@options)
     assert_instance_of SynapsePayRest::HTTPClient, client.client
     assert_instance_of SynapsePayRest::Users, client.users
     assert_instance_of SynapsePayRest::Nodes, client.nodes
@@ -41,16 +41,16 @@ class ClientTest < Minitest::Test
 
   # @todo turn on response logging as well as requests
   def test_logging_flags
-    client = SynapsePayRest::Client.new(@options)
+    client = SynapsePayRest::Client.new(**@options)
     assert_silent { client.users.create(payload: test_users_create_payload) }
 
     @options[:logging] = true
-    client = SynapsePayRest::Client.new(@options)
+    client = SynapsePayRest::Client.new(**@options)
     assert_output { client.users.create(payload: test_users_create_payload) }
 
     log_file = fixture_path('test.txt')
     @options[:log_to] = log_file
-    client = SynapsePayRest::Client.new(@options)
+    client = SynapsePayRest::Client.new(**@options)
     assert_output { client.users.create(payload: test_users_create_payload) }
 
     # cleanup
@@ -58,7 +58,7 @@ class ClientTest < Minitest::Test
   end
 
   def test_issue_public_key
-    client = SynapsePayRest::Client.new(@options)
+    client = SynapsePayRest::Client.new(**@options)
     response = client.issue_public_key(scope: 'CLIENT|CONTROLS')
 
     assert_equal ['CLIENT|CONTROLS'], response.scope
@@ -66,7 +66,7 @@ class ClientTest < Minitest::Test
   end
 
   def test_crypto_quote
-    client = SynapsePayRest::Client.new(@options)
+    client = SynapsePayRest::Client.new(**@options)
     response = client.get_crypto_quotes
 
     refute_nil response.btcusd


### PR DESCRIPTION
[ch17358] [ch17361] [ch17364] [ch17365]
We faced argument mismatch issues while running the testcases, because keyword parameters used in all testcases in SynapseFI-Ruby minitest, But Keyword parameters are deprecated in latest ruby versions. 

(Ref: [Separation of positional and keyword arguments in Ruby 3.0 (ruby-lang.org)] 
(https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/)).

 So, I have rewritten to adopt new changes in all testcases related to this issue. Even though the testcases are not relevant to current ticket.
 
 Note: We might need to rewrite all testcases in this gem to avoid/adopt above mentioned issue.
 
 
In Faker gem also faced some issue, so there also I upgrade the version and dependent changes also did.